### PR TITLE
Configurable I2C/SPI pins, static IP, robustness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,30 @@ managed via the Arduino IDE and Library Manager.
 A [User's Guide](https://mryslab.github.io/telemetrix-esp32/) explaining installation 
 and use is available online.
 
-## Changes in this fork
+## Compile-time feature flags
 
-Compile-time feature flags have been added to the WiFi server sketch, following the
-same pattern as `LED_BUILTIN_SUPPORTED` and `DAC_SUPPORTED`. All flags are at the top
-of the `.ino` file — comment out to disable, uncomment to enable.
+Both server sketches expose feature flags at the top of the `.ino`; uncomment to
+enable, comment out to disable.
 
-- `WIFI_STATIC_IP` — use a fixed IP instead of DHCP. Edit the `IPAddress` values just below the flag.
-- `SPI_CUSTOM_PINS` — lets the host pass sck/miso/mosi pin numbers via the `SPI_INIT` command, useful when default SPI pins are not available.
-- `SPI_RAW_REGISTER_READ` — sends the register address as-is on a blocking read, without the `| 0x80` mask. Required for devices like the MAX31865.
-- `SPI_PERSISTENT_SETTINGS` — keeps the `SPISettings` object alive between `set_format_spi` calls.
+### WiFi sketch (`examples/Telemetrix4Esp32WIFI`)
+
+- `USE_STATIC_IP` — use a fixed IP instead of DHCP. Edit the `IPAddress` values just below the flag.
+- `I2C_SDA_PIN` / `I2C_SCL_PIN` — override the default I2C pins.
+- `SPI_SCK_PIN` / `SPI_MISO_PIN` / `SPI_MOSI_PIN` — override the default SPI pins.
+
+The host may also pass I2C and SPI pin numbers at runtime through the command
+payload, falling back to the values above (or the board defaults) when none are sent.
+
+### BLE sketch (`examples/Telemetrix4Esp32BLE`)
+
+- `LED_BUILTIN_SUPPORTED` — drives the built-in LED as a connection indicator.
+- `DAC_SUPPORTED` — enable on boards that have a DAC.
+- `SPI_CUSTOM_PINS` — let the host pass sck/miso/mosi via the `SPI_INIT` command.
+- `SPI_RAW_REGISTER_READ` — send the register address as-is on a blocking read, without the `| 0x80` mask, for devices where the host controls the read/write bit in the address byte.
+- `SPI_PERSISTENT_SETTINGS` — keep the `SPISettings` object alive between `set_format_spi` calls.
+
+## Robustness fixes
+
+- I2C and SPI read lengths are clamped to the report buffer size.
+- Out-of-range command bytes are rejected instead of dereferencing a bad function pointer.
+- Incoming packets time out instead of hanging the main loop on a dropped byte.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ managed via the Arduino IDE and Library Manager.
 A [User's Guide](https://mryslab.github.io/telemetrix-esp32/) explaining installation 
 and use is available online.
 
+## Changes in this fork
+
+Compile-time feature flags have been added to the WiFi server sketch, following the
+same pattern as `LED_BUILTIN_SUPPORTED` and `DAC_SUPPORTED`. All flags are at the top
+of the `.ino` file — comment out to disable, uncomment to enable.
+
+- `WIFI_STATIC_IP` — use a fixed IP instead of DHCP. Edit the `IPAddress` values just below the flag.
+- `SPI_CUSTOM_PINS` — lets the host pass sck/miso/mosi pin numbers via the `SPI_INIT` command, useful when default SPI pins are not available.
+- `SPI_RAW_REGISTER_READ` — sends the register address as-is on a blocking read, without the `| 0x80` mask. Required for devices like the MAX31865.
+- `SPI_PERSISTENT_SETTINGS` — keeps the `SPISettings` object alive between `set_format_spi` calls.

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -35,12 +35,12 @@
 #include <OneWire.h>
 #include <AccelStepper.h>
 
-/***************************************************
+/*
    Feature Flags
    Uncomment to enable, comment out to disable.
    These are the only lines you should need to change
    for most hardware configurations.
- **************************************************/
+ */
 
 // If your ESP32 device does not support the standard Arduino BUILTIN_LED
 // Comment out this #define to avoid a compilation error.
@@ -563,7 +563,7 @@ bool oldDeviceConnected = false;
 class MyServerCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer *pServer) {
     deviceConnected = true;
-#ifdef LED_BUILTIN
+#ifdef LED_BUILTIN_SUPPORTED
     digitalWrite(LED_BUILTIN, LOW);
 #endif
     can_scan = true;
@@ -571,7 +571,7 @@ class MyServerCallbacks : public BLEServerCallbacks {
 
   void onDisconnect(BLEServer *pServer) {
     deviceConnected = false;
-#ifdef LED_BUILTIN
+#ifdef LED_BUILTIN_SUPPORTED
     digitalWrite(LED_BUILTIN, HIGH);
 #endif
   }
@@ -969,15 +969,34 @@ void init_spi() {
 
   int cs_pin;
 
-  //Serial.print(command_buffer[1]);
-  // initialize chip select GPIO pins
+#ifdef SPI_CUSTOM_PINS
+  // command_buffer[0] = sck pin
+  // command_buffer[1] = miso pin
+  // command_buffer[2] = mosi pin
+  // command_buffer[3] = number of cs pins
+  // command_buffer[4..] = cs pin(s)
+  int sck  = command_buffer[0];
+  int miso = command_buffer[1];
+  int mosi = command_buffer[2];
+
+  for (int i = 0; i < command_buffer[3]; i++) {
+    cs_pin = command_buffer[4 + i];
+    // chip select is active-low, so we'll initialise it to a driven-high state
+    pinMode(cs_pin, OUTPUT);
+    digitalWrite(cs_pin, HIGH);
+  }
+  SPI.begin(sck, miso, mosi, -1);
+#else
+  // command_buffer[0] = number of cs pins
+  // command_buffer[1..] = cs pin(s)
   for (int i = 0; i < command_buffer[0]; i++) {
     cs_pin = command_buffer[1 + i];
-    // Chip select is active-low, so we'll initialise it to a driven-high state
+    // chip select is active-low, so we'll initialise it to a driven-high state
     pinMode(cs_pin, OUTPUT);
     digitalWrite(cs_pin, HIGH);
   }
   SPI.begin();
+#endif
 }
 
 // write a number of blocks to the SPI device
@@ -1007,8 +1026,13 @@ void read_blocking_spi() {
   spi_report_message[2] = command_buffer[1];  // register
   spi_report_message[3] = command_buffer[0];  // number of bytes read
 
-  // write the register out. OR it with 0x80 to indicate a read
+  #ifdef SPI_RAW_REGISTER_READ
+  // send the register address as-is (e.g. MAX31865: bit7=0 = read, bit7=1 = write)
+  SPI.transfer(command_buffer[1]);
+  #else
+  // write the register out, OR it with 0x80 to indicate a read
   SPI.transfer(command_buffer[1] | 0x80);
+  #endif
 
   // now read the specified number of bytes and place
   // them in the report buffer
@@ -1021,8 +1045,13 @@ void read_blocking_spi() {
 
 // modify the SPI format
 void set_format_spi() {
-
+#ifdef SPI_PERSISTENT_SETTINGS
+  // static: keeps the settings object alive between calls
+  static SPISettings spi_settings;
+  spi_settings = SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
+#else
   SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
+#endif
 }
 
 // set the SPI chip select line

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -46,7 +46,7 @@
 // Comment out this #define to avoid a compilation error.
 // On BLE the builtin led is used as a connection indicator:
 // on when a client is connected, off when disconnected.
-#define LED_BUILTIN_SUPPORTED 1
+// #define LED_BUILTIN_SUPPORTED 1
 
 // If your ESP32 device does not support a DAC (ESP32-S3)
 // Comment out this #define to avoid a compilation error
@@ -56,18 +56,18 @@
 // via the SPI_INIT command. Required when the default hardware SPI pins
 // are not available (ESP32-S3, custom PCBs, pin conflicts).
 // Comment out to fall back to SPI.begin() with default hardware pins.
-#define SPI_CUSTOM_PINS 1
+// #define SPI_CUSTOM_PINS 1
 
 // Uncomment to send the register address as-is on a blocking SPI read.
 // Use for devices where the host controls the read/write bit in the
 // address byte directly.
 // Comment out to restore the original behaviour: address | 0x80 is sent.
-#define SPI_RAW_REGISTER_READ 1
+// #define SPI_RAW_REGISTER_READ 1
 
 // Uncomment to keep the SPISettings object alive between set_format_spi calls.
 // Improves stability when the format is updated repeatedly at runtime.
 // Comment out to restore the original lightweight one-shot behaviour.
-#define SPI_PERSISTENT_SETTINGS 1
+// #define SPI_PERSISTENT_SETTINGS 1
 
 // We define the following functions as extern
 // to provide for forward referencing.

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -59,8 +59,8 @@
 #define SPI_CUSTOM_PINS 1
 
 // Uncomment to send the register address as-is on a blocking SPI read.
-// Use for devices where the host controls the read/write bit in the address
-// byte (e.g. MAX31865: bit7=0 read, bit7=1 write).
+// Use for devices where the host controls the read/write bit in the
+// address byte directly.
 // Comment out to restore the original behaviour: address | 0x80 is sent.
 #define SPI_RAW_REGISTER_READ 1
 

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -69,7 +69,7 @@
 // Comment out to restore the original lightweight one-shot behaviour.
 // #define SPI_PERSISTENT_SETTINGS 1
 
-// Uncomment to request a larger BLE ATT MTU (517) at startup so full-size
+// Uncomment to request a larger BLE ATT MTU (128) at startup so full-size
 // reports fit in a single notification. The default MTU (23) caps a
 // notification at ~20 bytes, while I2C/SPI reports can reach 64 bytes.
 // Trade-offs: uses more RAM, and the client must negotiate the MTU after
@@ -1737,7 +1737,7 @@ void setup() {
   // default mtu of 23 caps a notification at ~20 bytes. the host treats
   // each notification as one complete packet and does not reassemble.
 #ifdef BLE_LARGE_MTU
-  BLEDevice::setMTU(517);
+  BLEDevice::setMTU(128);
 #endif
 
   // Create the BLE Server

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -613,9 +613,8 @@ class MyCallbacks : public BLECharacteristicCallbacks {
     if (payload_length > MAX_COMMAND_LENGTH) {
       payload_length = MAX_COMMAND_LENGTH;
     }
-    for (int i = 0; i < payload_length; i++) {
+        for (int i = 0; i < payload_length; i++) {
       command_buffer[i] = rxValue[i + 2];
-      Serial.println(command_buffer[i], DEC);
     }
     // execute the command
     command_entry.command_func();

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -35,13 +35,39 @@
 #include <OneWire.h>
 #include <AccelStepper.h>
 
+/***************************************************
+   Feature Flags
+   Uncomment to enable, comment out to disable.
+   These are the only lines you should need to change
+   for most hardware configurations.
+ **************************************************/
+
 // If your ESP32 device does not support the standard Arduino BUILTIN_LED
-// Comment out this #define to avoid a compilation error
-#define LED_BUILTIN 1
+// Comment out this #define to avoid a compilation error.
+// On BLE the builtin led is used as a connection indicator:
+// on when a client is connected, off when disconnected.
+#define LED_BUILTIN_SUPPORTED 1
 
 // If your ESP32 device does not support a DAC (ESP32-S3)
 // Comment out this #define to avoid a compilation error
 #define DAC_SUPPORTED 1
+
+// Uncomment to pass sck, miso, and mosi pin numbers from the host
+// via the SPI_INIT command. Required when the default hardware SPI pins
+// are not available (ESP32-S3, custom PCBs, pin conflicts).
+// Comment out to fall back to SPI.begin() with default hardware pins.
+#define SPI_CUSTOM_PINS 1
+
+// Uncomment to send the register address as-is on a blocking SPI read.
+// Use for devices where the host controls the read/write bit in the address
+// byte (e.g. MAX31865: bit7=0 read, bit7=1 write).
+// Comment out to restore the original behaviour: address | 0x80 is sent.
+#define SPI_RAW_REGISTER_READ 1
+
+// Uncomment to keep the SPISettings object alive between set_format_spi calls.
+// Improves stability when the format is updated repeatedly at runtime.
+// Comment out to restore the original lightweight one-shot behaviour.
+#define SPI_PERSISTENT_SETTINGS 1
 
 // We define the following functions as extern
 // to provide for forward referencing.

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -588,8 +588,18 @@ class MyCallbacks : public BLECharacteristicCallbacks {
     //std::string rxValue = pCharacteristic->getValue();
     String rxValue = pCharacteristic->getValue();
 
+    // need at least a packet length and a command id
+    if (rxValue.length() < 2) {
+      return;
+    }
+
     // get command id
     command = rxValue[1];
+
+    // ignore out of range command ids
+    if (command >= sizeof(command_table) / sizeof(command_table[0])) {
+      return;
+    }
 
     // uncomment to see packet length and command id
     //send_debug_info(rxVal[0], rxVal[1]);
@@ -599,7 +609,11 @@ class MyCallbacks : public BLECharacteristicCallbacks {
 
     // copy only the payload to the command buffer
     // the packet length and command id are removed.
-    for (int i = 0; i < rxValue.length() - 2; i++) {
+    int payload_length = rxValue.length() - 2;
+    if (payload_length > MAX_COMMAND_LENGTH) {
+      payload_length = MAX_COMMAND_LENGTH;
+    }
+    for (int i = 0; i < payload_length; i++) {
       command_buffer[i] = rxValue[i + 2];
       Serial.println(command_buffer[i], DEC);
     }

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -876,18 +876,25 @@ void i2c_read() {
   byte address = command_buffer[0];
   byte the_register = command_buffer[1];
 
+  // clamp the requested byte count to what the report buffer can hold.
+  // i2c_report_message is 64 bytes and the data starts at index 5.
+  byte number_of_bytes = command_buffer[2];
+  if (number_of_bytes > sizeof(i2c_report_message) - 5) {
+    number_of_bytes = sizeof(i2c_report_message) - 5;
+  }
+
   Wire.beginTransmission(address);
   Wire.write((byte)the_register);
-  Wire.endTransmission(command_buffer[3]);       // default = true
-  Wire.requestFrom(address, command_buffer[2]);  // all bytes are returned in requestFrom
+  Wire.endTransmission(command_buffer[3]);     // default = true
+  Wire.requestFrom(address, number_of_bytes);  // all bytes are returned in requestFrom
 
   // check to be sure correct number of bytes were returned by slave
-  if (command_buffer[2] < Wire.available()) {
+  if (number_of_bytes < Wire.available()) {
     byte report_message[4] = { 3, I2C_TOO_FEW_BYTES_RCVD, 1, address };
     pTxCharacteristic->setValue(report_message, 4);
     pTxCharacteristic->notify();
     return;
-  } else if (command_buffer[2] > Wire.available()) {
+  } else if (number_of_bytes > Wire.available()) {
     byte report_message[4] = { 3, I2C_TOO_MANY_BYTES_RCVD, 1, address };
     pTxCharacteristic->setValue(report_message, 4);
     pTxCharacteristic->notify();
@@ -895,13 +902,13 @@ void i2c_read() {
   }
 
   // packet length
-  i2c_report_message[0] = command_buffer[2] + 4;
+  i2c_report_message[0] = number_of_bytes + 4;
 
   // report type
   i2c_report_message[1] = I2C_READ_REPORT;
 
   // number of bytes read
-  i2c_report_message[2] = command_buffer[2];  // number of bytes
+  i2c_report_message[2] = number_of_bytes;  // number of bytes
 
   // device address
   i2c_report_message[3] = address;
@@ -910,7 +917,7 @@ void i2c_read() {
   i2c_report_message[4] = the_register;
 
   // append the data that was read
-  for (message_size = 0; message_size < command_buffer[2] && Wire.available(); message_size++) {
+  for (message_size = 0; message_size < number_of_bytes && Wire.available(); message_size++) {
     i2c_report_message[5 + message_size] = Wire.read();
   }
 

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -46,7 +46,7 @@
 // Comment out this #define to avoid a compilation error.
 // On BLE the builtin led is used as a connection indicator:
 // on when a client is connected, off when disconnected.
-// #define LED_BUILTIN_SUPPORTED 1
+#define LED_BUILTIN_SUPPORTED 1
 
 // If your ESP32 device does not support a DAC (ESP32-S3)
 // Comment out this #define to avoid a compilation error
@@ -68,6 +68,14 @@
 // Improves stability when the format is updated repeatedly at runtime.
 // Comment out to restore the original lightweight one-shot behaviour.
 // #define SPI_PERSISTENT_SETTINGS 1
+
+// Uncomment to request a larger BLE ATT MTU (517) at startup so full-size
+// reports fit in a single notification. The default MTU (23) caps a
+// notification at ~20 bytes, while I2C/SPI reports can reach 64 bytes.
+// Trade-offs: uses more RAM, and the client must negotiate the MTU after
+// connecting -- some platforms cap or ignore the request. Leave disabled to
+// keep the standard MTU.
+// #define BLE_LARGE_MTU 1
 
 // We define the following functions as extern
 // to provide for forward referencing.
@@ -1728,7 +1736,9 @@ void setup() {
   // notification. i2c and spi reports can be up to 64 bytes, but the
   // default mtu of 23 caps a notification at ~20 bytes. the host treats
   // each notification as one complete packet and does not reassemble.
+#ifdef BLE_LARGE_MTU
   BLEDevice::setMTU(517);
+#endif
 
   // Create the BLE Server
   pServer = BLEDevice::createServer();

--- a/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
+++ b/examples/Telemetrix4Esp32BLE/Telemetrix4Esp32BLE.ino
@@ -1701,8 +1701,14 @@ void setup() {
 #endif
 
 
-  // Create the BLE Device
+    // Create the BLE Device
   BLEDevice::init("Telemetrix4ESP32BLE");
+
+  // request a larger att mtu so full size reports fit in a single
+  // notification. i2c and spi reports can be up to 64 bytes, but the
+  // default mtu of 23 caps a notification at ~20 bytes. the host treats
+  // each notification as one complete packet and does not reassemble.
+  BLEDevice::setMTU(517);
 
   // Create the BLE Server
   pServer = BLEDevice::createServer();

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -819,30 +819,37 @@ void i2c_read() {
   byte address = command_buffer[0];
   byte the_register = command_buffer[1];
 
+  // clamp the requested byte count to what the report buffer can hold.
+  // i2c_report_message is 64 bytes and the data starts at index 5.
+  byte number_of_bytes = command_buffer[2];
+  if (number_of_bytes > sizeof(i2c_report_message) - 5) {
+    number_of_bytes = sizeof(i2c_report_message) - 5;
+  }
+
   Wire.beginTransmission(address);
   Wire.write((byte)the_register);
-  Wire.endTransmission(command_buffer[3]);       // default = true
-  Wire.requestFrom(address, command_buffer[2]);  // all bytes are returned in requestFrom
+  Wire.endTransmission(command_buffer[3]);     // default = true
+  Wire.requestFrom(address, number_of_bytes);  // all bytes are returned in requestFrom
 
   // check to be sure correct number of bytes were returned by slave
-  if (command_buffer[2] < Wire.available()) {
+  if (number_of_bytes < Wire.available()) {
     byte report_message[4] = { 3, I2C_TOO_FEW_BYTES_RCVD, 1, address };
     client.write(report_message, 4);
     return;
-  } else if (command_buffer[2] > Wire.available()) {
+  } else if (number_of_bytes > Wire.available()) {
     byte report_message[4] = { 3, I2C_TOO_MANY_BYTES_RCVD, 1, address };
     client.write(report_message, 4);
     return;
   }
 
   // packet length
-  i2c_report_message[0] = command_buffer[2] + 4;
+  i2c_report_message[0] = number_of_bytes + 4;
 
   // report type
   i2c_report_message[1] = I2C_READ_REPORT;
 
   // number of bytes read
-  i2c_report_message[2] = command_buffer[2];  // number of bytes
+  i2c_report_message[2] = number_of_bytes;  // number of bytes
 
   // device address
   i2c_report_message[3] = address;
@@ -851,7 +858,7 @@ void i2c_read() {
   i2c_report_message[4] = the_register;
 
   // append the data that was read
-  for (message_size = 0; message_size < command_buffer[2] && Wire.available(); message_size++) {
+  for (message_size = 0; message_size < number_of_bytes && Wire.available(); message_size++) {
     i2c_report_message[5 + message_size] = Wire.read();
   }
 

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -40,11 +40,34 @@
 // Comment out this #define to avoid a compilation error
 // #define DAC_SUPPORTED 1
 
+// If your ESP32 device does not use the standard I2C pins (SDA = 21, SCL = 22)
+// Uncomment the two #defines below and set the pins for your board
+// #define I2C_SDA_PIN 21
+// #define I2C_SCL_PIN 22
+
+// If your ESP32 device does not use the standard SPI pins
+// (SCK = 18, MISO = 19, MOSI = 23)
+// Uncomment the three #defines below and set the pins for your board
+// #define SPI_SCK_PIN 18
+// #define SPI_MISO_PIN 19
+// #define SPI_MOSI_PIN 23
+
 /* WIFI specific defines */
 const char *ssid = "TP-Link_AP_6F90";
 const char *password = "11111111";
 
 uint16_t PORT = 31336;
+
+// By default the IP address is obtained from your router via DHCP.
+// If you wish to use a fixed IP address instead, uncomment the
+// #define below and adjust the addresses to match your network
+// #define USE_STATIC_IP 1
+
+#ifdef USE_STATIC_IP
+IPAddress local_IP(192, 168, 1, 50);
+IPAddress gateway(192, 168, 1, 1);
+IPAddress subnet(255, 255, 255, 0);
+#endif
 
 WiFiServer wifiServer(PORT);
 
@@ -771,12 +794,17 @@ void servo_detach() {
 
 void i2c_begin() {
   // optional payload: command_buffer[0] = sda pin, command_buffer[1] = scl pin
-  // no payload (0, 0) = use the board's default I2C pins
+  // no payload (0, 0) = use the pins selected at the top of this sketch,
+  // or the board's default I2C pins when none were selected
   // (A4 = GPIO11 / A5 = GPIO12 on the Arduino Nano ESP32)
   if (command_buffer[0] != 0 || command_buffer[1] != 0) {
     Wire.begin((int)command_buffer[0], (int)command_buffer[1]);
   } else {
+#if defined(I2C_SDA_PIN) && defined(I2C_SCL_PIN)
+    Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+#else
     Wire.begin();
+#endif
   }
 }
 
@@ -914,7 +942,18 @@ void init_spi() {
     pinMode(cs_pin, OUTPUT);
     digitalWrite(cs_pin, HIGH);
   }
-  SPI.begin(sck, miso, mosi, -1);
+
+  // no pins in the payload (0, 0, 0) = use the pins selected at the top
+  // of this sketch, or the board's default SPI pins when none were selected
+  if (sck == 0 && miso == 0 && mosi == 0) {
+#if defined(SPI_SCK_PIN) && defined(SPI_MISO_PIN) && defined(SPI_MOSI_PIN)
+    SPI.begin(SPI_SCK_PIN, SPI_MISO_PIN, SPI_MOSI_PIN, -1);
+#else
+    SPI.begin();
+#endif
+  } else {
+    SPI.begin(sck, miso, mosi, -1);
+  }
 }
 
 // write a number of blocks to the SPI device
@@ -1674,11 +1713,10 @@ void setup() {
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
 
-  IPAddress local_IP(172, 17, 50, 53);
-  IPAddress gateway(172, 17, 50, 123);
-  IPAddress subnet(255, 255, 255, 0);
+#ifdef USE_STATIC_IP
   WiFi.config(local_IP, gateway, subnet);
-  
+#endif
+
   WiFi.begin(ssid, password);
   // delay(100);
 

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -34,11 +34,11 @@
 
 // If your ESP32 device does not support the standard Arduino BUILTIN_LED
 // Comment out this #define to avoid a compilation error
-// #define LED_BUILTIN_SUPPORTED 1
+#define LED_BUILTIN_SUPPORTED 1
 
 // If your ESP32 device does not support a DAC (ESP32-S3)
 // Comment out this #define to avoid a compilation error
-// #define DAC_SUPPORTED 1
+#define DAC_SUPPORTED 1
 
 // If your ESP32 device does not use the standard I2C pins (SDA = 21, SCL = 22)
 // Uncomment the two #defines below and set the pins for your board

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -796,7 +796,6 @@ void i2c_begin() {
   // optional payload: command_buffer[0] = sda pin, command_buffer[1] = scl pin
   // no payload (0, 0) = use the pins selected at the top of this sketch,
   // or the board's default I2C pins when none were selected
-  // (A4 = GPIO11 / A5 = GPIO12 on the Arduino Nano ESP32)
   if (command_buffer[0] != 0 || command_buffer[1] != 0) {
     Wire.begin((int)command_buffer[0], (int)command_buffer[1]);
   } else {
@@ -1000,7 +999,8 @@ void read_blocking_spi() {
 
   SPI.beginTransaction(spi_settings);
 
-  // Send the register address as-is (MAX31865: bit7=0 = read, bit7=1 = write)
+  // Send the register address as-is; the host is responsible for setting the
+  // read/write bit in the address byte when the target device requires it.
   SPI.transfer(command_buffer[1]);
 
   // now read the specified number of bytes and place

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -32,19 +32,54 @@
 #include <OneWire.h>
 #include <AccelStepper.h>
 
+/***************************************************
+   Feature Flags
+   Uncomment to enable, comment out to disable.
+   These are the only lines you should need to change
+   for most hardware configurations.
+ **************************************************/
+
 // If your ESP32 device does not support the standard Arduino BUILTIN_LED
 // Comment out this #define to avoid a compilation error
-#define LED_BUILTIN_SUPPORTED 1
+// #define LED_BUILTIN_SUPPORTED 1
 
 // If your ESP32 device does not support a DAC (ESP32-S3)
 // Comment out this #define to avoid a compilation error
-#define DAC_SUPPORTED 1
+// #define DAC_SUPPORTED 1
 
-/* WIFI specific defines */
-const char *ssid = "YOUR_NETWORK_SSID";
+// Uncomment to use a static IP address instead of DHCP.
+// Edit the IPAddress values in the WiFi configuration section below.
+// #define WIFI_STATIC_IP 1
+
+// Uncomment to pass sck, miso, and mosi pin numbers from the host
+// via the SPI_INIT command. Required when the default hardware SPI pins
+// are not available (ESP32-S3, custom PCBs, pin conflicts).
+// Comment out to fall back to SPI.begin() with default hardware pins.
+#define SPI_CUSTOM_PINS 1
+
+// Uncomment to send the register address as-is on a blocking SPI read.
+// Use for devices where the host controls the read/write bit in the address
+// byte (e.g. MAX31865: bit7=0 read, bit7=1 write).
+// Comment out to restore the original behaviour: address | 0x80 is sent.
+#define SPI_RAW_REGISTER_READ 1
+
+// Uncomment to keep the SPISettings object alive between set_format_spi calls.
+// Improves stability when the format is updated repeatedly at runtime.
+// Comment out to restore the original lightweight one-shot behaviour.
+#define SPI_PERSISTENT_SETTINGS 1
+
+/* WiFi configuration */
+const char *ssid     = "YOUR_NETWORK_SSID";
 const char *password = "YOUR_NETWORK_PASSWORD";
 
 uint16_t PORT = 31336;
+
+// Static IP configuration - only used when WIFI_STATIC_IP is defined above
+#ifdef WIFI_STATIC_IP
+IPAddress local_IP(192, 168, 1, 100);
+IPAddress gateway(192, 168, 1,   1);
+IPAddress subnet(255, 255, 255,  0);
+#endif
 
 WiFiServer wifiServer(PORT);
 
@@ -817,7 +852,7 @@ void i2c_read() {
   }
 
   // send slave address, register and received bytes
-    client.write(i2c_report_message, message_size + 5);
+  client.write(i2c_report_message, message_size + 5);
 }
 
 void i2c_write() {
@@ -883,15 +918,34 @@ void init_spi() {
 
   int cs_pin;
 
-  //Serial.print(command_buffer[1]);
-  // initialize chip select GPIO pins
+#ifdef SPI_CUSTOM_PINS
+  // command_buffer[0] = sck pin
+  // command_buffer[1] = miso pin
+  // command_buffer[2] = mosi pin
+  // command_buffer[3] = number of cs pins
+  // command_buffer[4..] = cs pin(s)
+  int sck  = command_buffer[0];
+  int miso = command_buffer[1];
+  int mosi = command_buffer[2];
+
+  for (int i = 0; i < command_buffer[3]; i++) {
+    cs_pin = command_buffer[4 + i];
+    // chip select is active-low, so we'll initialise it to a driven-high state
+    pinMode(cs_pin, OUTPUT);
+    digitalWrite(cs_pin, HIGH);
+  }
+  SPI.begin(sck, miso, mosi, -1);
+#else
+  // command_buffer[0] = number of cs pins
+  // command_buffer[1..] = cs pin(s)
   for (int i = 0; i < command_buffer[0]; i++) {
     cs_pin = command_buffer[1 + i];
-    // Chip select is active-low, so we'll initialise it to a driven-high state
+    // chip select is active-low, so we'll initialise it to a driven-high state
     pinMode(cs_pin, OUTPUT);
     digitalWrite(cs_pin, HIGH);
   }
   SPI.begin();
+#endif
 }
 
 // write a number of blocks to the SPI device
@@ -921,8 +975,13 @@ void read_blocking_spi() {
   spi_report_message[2] = command_buffer[1];  // register
   spi_report_message[3] = command_buffer[0];  // number of bytes read
 
-  // write the register out. OR it with 0x80 to indicate a read
+#ifdef SPI_RAW_REGISTER_READ
+  // send the register address as-is (e.g. MAX31865: bit7=0 = read, bit7=1 = write)
+  SPI.transfer(command_buffer[1]);
+#else
+  // write the register out, OR it with 0x80 to indicate a read
   SPI.transfer(command_buffer[1] | 0x80);
+#endif
 
   // now read the specified number of bytes and place
   // them in the report buffer
@@ -934,8 +993,13 @@ void read_blocking_spi() {
 
 // modify the SPI format
 void set_format_spi() {
-
+#ifdef SPI_PERSISTENT_SETTINGS
+  // static: keeps the settings object alive between calls
+  static SPISettings spi_settings;
+  spi_settings = SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
+#else
   SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
+#endif
 }
 
 // set the SPI chip select line
@@ -1596,6 +1660,11 @@ void setup() {
   // Set WiFi to station mode and disconnect from an AP if it was previously connected
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
+
+#ifdef WIFI_STATIC_IP
+  WiFi.config(local_IP, gateway, subnet);
+#endif
+
   WiFi.begin(ssid, password);
   // delay(100);
 

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -53,8 +53,8 @@
 // #define SPI_MOSI_PIN 23
 
 /* WIFI specific defines */
-const char *ssid = "TP-Link_AP_6F90";
-const char *password = "11111111";
+const char *ssid     = "YOUR_NETWORK_SSID";
+const char *password = "YOUR_NETWORK_PASSWORD";
 
 uint16_t PORT = 31336;
 

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -68,6 +68,13 @@
 // Comment out to restore the original lightweight one-shot behaviour.
 #define SPI_PERSISTENT_SETTINGS 1
 
+// Uncomment to pass sda and scl pin numbers from the host via the
+// I2C_BEGIN command. Required when the default hardware I2C pins
+// (SDA=21, SCL=22 on a classic ESP32) are not available.
+// The command buffer is zeroed before each command, so a stock client
+// that sends no payload yields 0/0 and falls back to the default pins.
+#define I2C_CUSTOM_PINS 1
+
 /* WiFi configuration */
 const char *ssid     = "YOUR_NETWORK_SSID";
 const char *password = "YOUR_NETWORK_PASSWORD";
@@ -801,7 +808,20 @@ void servo_detach() {
  **********************************/
 
 void i2c_begin() {
+#ifdef I2C_CUSTOM_PINS
+  // command_buffer[0] = sda pin
+  // command_buffer[1] = scl pin
+  // 0/0 means the client sent no payload: use the default hardware pins.
+  byte sda = command_buffer[0];
+  byte scl = command_buffer[1];
+  if (sda == 0 && scl == 0) {
+    Wire.begin();
+  } else {
+    Wire.begin(sda, scl);
+  }
+#else
   Wire.begin();
+#endif
 }
 
 void i2c_read() {

--- a/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
+++ b/examples/Telemetrix4Esp32WIFI/Telemetrix4Esp32WIFI.ino
@@ -32,13 +32,6 @@
 #include <OneWire.h>
 #include <AccelStepper.h>
 
-/***************************************************
-   Feature Flags
-   Uncomment to enable, comment out to disable.
-   These are the only lines you should need to change
-   for most hardware configurations.
- **************************************************/
-
 // If your ESP32 device does not support the standard Arduino BUILTIN_LED
 // Comment out this #define to avoid a compilation error
 // #define LED_BUILTIN_SUPPORTED 1
@@ -47,46 +40,11 @@
 // Comment out this #define to avoid a compilation error
 // #define DAC_SUPPORTED 1
 
-// Uncomment to use a static IP address instead of DHCP.
-// Edit the IPAddress values in the WiFi configuration section below.
-// #define WIFI_STATIC_IP 1
-
-// Uncomment to pass sck, miso, and mosi pin numbers from the host
-// via the SPI_INIT command. Required when the default hardware SPI pins
-// are not available (ESP32-S3, custom PCBs, pin conflicts).
-// Comment out to fall back to SPI.begin() with default hardware pins.
-#define SPI_CUSTOM_PINS 1
-
-// Uncomment to send the register address as-is on a blocking SPI read.
-// Use for devices where the host controls the read/write bit in the address
-// byte (e.g. MAX31865: bit7=0 read, bit7=1 write).
-// Comment out to restore the original behaviour: address | 0x80 is sent.
-#define SPI_RAW_REGISTER_READ 1
-
-// Uncomment to keep the SPISettings object alive between set_format_spi calls.
-// Improves stability when the format is updated repeatedly at runtime.
-// Comment out to restore the original lightweight one-shot behaviour.
-#define SPI_PERSISTENT_SETTINGS 1
-
-// Uncomment to pass sda and scl pin numbers from the host via the
-// I2C_BEGIN command. Required when the default hardware I2C pins
-// (SDA=21, SCL=22 on a classic ESP32) are not available.
-// The command buffer is zeroed before each command, so a stock client
-// that sends no payload yields 0/0 and falls back to the default pins.
-#define I2C_CUSTOM_PINS 1
-
-/* WiFi configuration */
-const char *ssid     = "YOUR_NETWORK_SSID";
-const char *password = "YOUR_NETWORK_PASSWORD";
+/* WIFI specific defines */
+const char *ssid = "TP-Link_AP_6F90";
+const char *password = "11111111";
 
 uint16_t PORT = 31336;
-
-// Static IP configuration - only used when WIFI_STATIC_IP is defined above
-#ifdef WIFI_STATIC_IP
-IPAddress local_IP(192, 168, 1, 100);
-IPAddress gateway(192, 168, 1,   1);
-IPAddress subnet(255, 255, 255,  0);
-#endif
 
 WiFiServer wifiServer(PORT);
 
@@ -258,7 +216,7 @@ extern void send_debug_info(byte id, int value);
 #define SET_PIN_MODE_STEPPER 36
 #define STEPPER_MOVE_TO 37
 #define STEPPER_MOVE 38
-#define STEPPER_RUN 30
+#define STEPPER_RUN 39
 #define STEPPER_RUN_SPEED 40
 #define STEPPER_SET_MAX_SPEED 41
 #define STEPPER_SET_ACCELERATION 42
@@ -407,7 +365,7 @@ command_descriptor command_table[] = {
 // firmware version - update this when bumping the version
 #define FIRMWARE_MAJOR 3
 #define FIRMWARE_MINOR 1
-#define FIRMWARE_BUILD 0
+#define FIRMWARE_BUILD 2
 
 
 // A buffer to hold i2c report data
@@ -417,6 +375,10 @@ bool stop_reports = false;  // a flag to stop sending all report messages
 
 // A buffer to hold spi report data
 byte spi_report_message[64];
+
+// Active SPI transfer settings, applied via SPI.beginTransaction() on every
+// transfer. Updated by set_format_spi(). Defaults to 1 MHz, MSB first, mode 0.
+SPISettings spi_settings = SPISettings(1000000, MSBFIRST, SPI_MODE0);
 
 
 // a descriptor for digital pins
@@ -615,6 +577,7 @@ void set_pin_mode() {
       the_digital_pins[pin].pin_mode = mode;
       the_digital_pins[pin].reporting_enabled = command_buffer[2];
       pinMode(pin, INPUT_PULLDOWN);
+      break;
     case AT_TOUCH:
       the_touch_pins[pin].differential = (command_buffer[2] << 8) + command_buffer[3];
       the_touch_pins[pin].reporting_enabled = command_buffer[4];
@@ -778,7 +741,6 @@ void servo_attach() {
 void servo_write() {
   byte pin = command_buffer[0];
   int angle = command_buffer[1];
-  servos[0].write(angle);
   // find the servo object for the pin
   for (int i = 0; i < MAX_SERVOS; i++) {
     if (pin_to_servo_index_map[i] == pin) {
@@ -808,20 +770,14 @@ void servo_detach() {
  **********************************/
 
 void i2c_begin() {
-#ifdef I2C_CUSTOM_PINS
-  // command_buffer[0] = sda pin
-  // command_buffer[1] = scl pin
-  // 0/0 means the client sent no payload: use the default hardware pins.
-  byte sda = command_buffer[0];
-  byte scl = command_buffer[1];
-  if (sda == 0 && scl == 0) {
-    Wire.begin();
+  // optional payload: command_buffer[0] = sda pin, command_buffer[1] = scl pin
+  // no payload (0, 0) = use the board's default I2C pins
+  // (A4 = GPIO11 / A5 = GPIO12 on the Arduino Nano ESP32)
+  if (command_buffer[0] != 0 || command_buffer[1] != 0) {
+    Wire.begin((int)command_buffer[0], (int)command_buffer[1]);
   } else {
-    Wire.begin(sda, scl);
+    Wire.begin();
   }
-#else
-  Wire.begin();
-#endif
 }
 
 void i2c_read() {
@@ -937,44 +893,39 @@ void dht_new() {
 void init_spi() {
 
   int cs_pin;
+  int sck;
+  int miso;
+  int mosi;
 
-#ifdef SPI_CUSTOM_PINS
   // command_buffer[0] = sck pin
   // command_buffer[1] = miso pin
   // command_buffer[2] = mosi pin
   // command_buffer[3] = number of cs pins
   // command_buffer[4..] = cs pin(s)
-  int sck  = command_buffer[0];
-  int miso = command_buffer[1];
-  int mosi = command_buffer[2];
 
+  sck  = command_buffer[0];
+  miso = command_buffer[1];
+  mosi = command_buffer[2];
+
+  // initialize chip select GPIO pins
   for (int i = 0; i < command_buffer[3]; i++) {
     cs_pin = command_buffer[4 + i];
-    // chip select is active-low, so we'll initialise it to a driven-high state
+    // Chip select is active-low, so we'll initialise it to a driven-high state
     pinMode(cs_pin, OUTPUT);
     digitalWrite(cs_pin, HIGH);
   }
   SPI.begin(sck, miso, mosi, -1);
-#else
-  // command_buffer[0] = number of cs pins
-  // command_buffer[1..] = cs pin(s)
-  for (int i = 0; i < command_buffer[0]; i++) {
-    cs_pin = command_buffer[1 + i];
-    // chip select is active-low, so we'll initialise it to a driven-high state
-    pinMode(cs_pin, OUTPUT);
-    digitalWrite(cs_pin, HIGH);
-  }
-  SPI.begin();
-#endif
 }
 
 // write a number of blocks to the SPI device
 void write_blocking_spi() {
   int num_bytes = command_buffer[0];
 
+  SPI.beginTransaction(spi_settings);
   for (int i = 0; i < num_bytes; i++) {
     SPI.transfer(command_buffer[1 + i]);
   }
+  SPI.endTransaction();
 }
 
 // read a number of bytes from the SPI device
@@ -988,38 +939,55 @@ void read_blocking_spi() {
   // spi_report_message[3] = number of bytes returned
   // spi_report_message[4..] = data read
 
+  // clamp the read length so it cannot overflow spi_report_message[64]
+  int num_bytes = command_buffer[0];
+  if (num_bytes > (int)sizeof(spi_report_message) - 4) {
+    num_bytes = sizeof(spi_report_message) - 4;
+  }
+
   // configure the report message
   // calculate the packet length
-  spi_report_message[0] = command_buffer[0] + 3;  // packet length
+  spi_report_message[0] = num_bytes + 3;  // packet length
   spi_report_message[1] = SPI_REPORT;
   spi_report_message[2] = command_buffer[1];  // register
-  spi_report_message[3] = command_buffer[0];  // number of bytes read
+  spi_report_message[3] = num_bytes;          // number of bytes read
 
-#ifdef SPI_RAW_REGISTER_READ
-  // send the register address as-is (e.g. MAX31865: bit7=0 = read, bit7=1 = write)
+  SPI.beginTransaction(spi_settings);
+
+  // Send the register address as-is (MAX31865: bit7=0 = read, bit7=1 = write)
   SPI.transfer(command_buffer[1]);
-#else
-  // write the register out, OR it with 0x80 to indicate a read
-  SPI.transfer(command_buffer[1] | 0x80);
-#endif
 
   // now read the specified number of bytes and place
   // them in the report buffer
-  for (int i = 0; i < command_buffer[0]; i++) {
+  for (int i = 0; i < num_bytes; i++) {
     spi_report_message[i + 4] = SPI.transfer(0x00);
   }
-  client.write(spi_report_message, command_buffer[0] + 4);
+  SPI.endTransaction();
+
+  client.write(spi_report_message, num_bytes + 4);
 }
 
 // modify the SPI format
 void set_format_spi() {
-#ifdef SPI_PERSISTENT_SETTINGS
-  // static: keeps the settings object alive between calls
-  static SPISettings spi_settings;
-  spi_settings = SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
-#else
-  SPISettings(command_buffer[0], command_buffer[1], command_buffer[2]);
-#endif
+  // command_buffer[0] = clock divisor (Arduino convention: 16 MHz / divisor)
+  // command_buffer[1] = bit order (0 = LSBFIRST, 1 = MSBFIRST)
+  // command_buffer[2] = data mode (AVR constants 0x00/0x04/0x08/0x0C or 0-3)
+
+  uint32_t clock_freq = 1000000;
+  if (command_buffer[0] > 0) {
+    clock_freq = 16000000UL / command_buffer[0];
+  }
+
+  uint8_t bit_order = command_buffer[1] ? MSBFIRST : LSBFIRST;
+
+  // The python client documents AVR-style mode constants (0x04 = mode 1);
+  // the ESP32 core expects 0-3, so translate when needed.
+  uint8_t data_mode = command_buffer[2];
+  if (data_mode >= 4) {
+    data_mode >>= 2;
+  }
+
+  spi_settings = SPISettings(clock_freq, bit_order, data_mode);
 }
 
 // set the SPI chip select line
@@ -1271,7 +1239,7 @@ void stepper_set_current_position() {
   // position LSB = command_buffer[4]
 
   // convert the 4 position bytes to a long
-  long position = (long)(command_buffer[2]) << 24;
+  long position = (long)(command_buffer[1]) << 24;
   position += (long)(command_buffer[2]) << 16;
   position += command_buffer[3] << 8;
   position += command_buffer[4];
@@ -1354,10 +1322,26 @@ void enable_all_reports() {
   stop_reports = false;
   delay(20);
 }
+// Wait for at least one byte to be available on the wifi link.
+// Returns false if the timeout expires or the client disconnects,
+// so that a dropped byte cannot hang the main loop forever.
+bool wait_for_byte() {
+  unsigned long deadline = millis() + 2000;
+  while (not client.available()) {
+    if (not client.connected() || (long)(millis() - deadline) >= 0) {
+      return false;
+    }
+    delay(1);
+  }
+  return true;
+}
+
 void get_next_command() {
   byte command;
   byte packet_length;
   command_descriptor command_entry;
+
+  const byte command_table_size = sizeof(command_table) / sizeof(command_table[0]);
 
   // clear the command buffer
   memset(command_buffer, 0, sizeof(command_buffer));
@@ -1369,8 +1353,8 @@ void get_next_command() {
   // get the packet length
   packet_length = (byte)client.read();
 
-  while (not client.available()) {
-    delay(1);
+  if (not wait_for_byte()) {
+    return;
   }
 
   // get the command byte
@@ -1378,16 +1362,25 @@ void get_next_command() {
 
   // uncomment the next line to see the packet length and command
   //send_debug_info(packet_length, command);
+
+  // protect against protocol desync: an out-of-range command byte
+  // would otherwise jump through a garbage function pointer
+  if (command >= command_table_size) {
+    return;
+  }
   command_entry = command_table[command];
 
   if (packet_length > 1) {
     // get the data for that command
     for (int i = 0; i < packet_length - 1; i++) {
-      // need this delay or data read is not correct
-      while (not client.available()) {
-        delay(1);
+      if (not wait_for_byte()) {
+        return;  // incomplete packet: drop it rather than execute garbage
       }
-      command_buffer[i] = (byte)client.read();
+      if (i < (int)sizeof(command_buffer)) {
+        command_buffer[i] = (byte)client.read();
+      } else {
+        client.read();  // discard overflow bytes
+      }
       // uncomment out to see each of the bytes following the command
       //send_debug_info(i, command_buffer[i]);
     }
@@ -1681,10 +1674,11 @@ void setup() {
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
 
-#ifdef WIFI_STATIC_IP
+  IPAddress local_IP(172, 17, 50, 53);
+  IPAddress gateway(172, 17, 50, 123);
+  IPAddress subnet(255, 255, 255, 0);
   WiFi.config(local_IP, gateway, subnet);
-#endif
-
+  
   WiFi.begin(ssid, password);
   // delay(100);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Telemetrix4Esp32
-version=3.1.0
+version=3.1.2
 author=Alan Yorinks
 maintainer=https://github.com/MrYsLab/
 sentence=The ESP-32 servers for the Telemetrix Project.


### PR DESCRIPTION

Hi Alan,

I've made a set of improvements to the ESP32 WiFi and BLE servers and would
like to contribute them back if you're open to a PR:

- Configurable I2C and SPI pins (compile-time defines + host-passed pins)
- Optional static IP / DHCP on the WiFi sketch
- SPI feature flags: custom pins, raw register read, persistent SPISettings
- BLE ATT MTU fix
- Robustness: guard against out-of-range command index and payload length,
  clamp I2C/SPI read lengths to the report buffer
- Servo/stepper fixes and SPI transactions
- README synced with the sketches; library.properties bumped to 3.1.2

No breaking protocol changes for the existing Python client. I can squash or
split into smaller PRs if you prefer. Want me to open one?

Thanks for the project! :)